### PR TITLE
fix: Correct JavaScript syntax error in app.js

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -569,7 +569,6 @@ async function pollJobStatus(jobId, progressCallback) {
 }
 
 function displayPracticeSet(practiceSet) {
-function displayPracticeSet(practiceSet) {
     currentPracticeSet = practiceSet; // Store the full practice set globally
 
     if (!practiceSet || !practiceSet.passage) {


### PR DESCRIPTION
Resolved an "Uncaught SyntaxError: Unexpected end of input" in static/js/app.js. The error was caused by a duplicated function signature for displayPracticeSet. Removed the redundant line to ensure the script is syntactically correct.